### PR TITLE
Use command line arguments to configure script

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -63,23 +63,6 @@ import tkinter
 tkinter.Tk().withdraw()
 from tkinter.filedialog import askdirectory
 
-# --- INTRO ---
-
-print('----- It\'s Learning dump script -----')
-print('Created by: Bart van Blokland (bart.van.blokland@ntnu.no)')
-print()
-print('Greetings! This script will help you download your content off of It\'s Learning.')
-print('We\'ll start by selecting a directory where all the files are going to be saved.')
-if os.name == 'nt':
-	print()
-	print('NOTE: Since you\'re a Windows user, please keep in mind that file paths can only be 255 characters long. This is a Windows limitation I can\'t do anything about.')
-	print('This script has a fallback option for files which can not be created due to this limitation by saving them to a single directory.')
-	print('For the best results, I recommend creating a folder in the root of your hard drive. For example; C:\\dump or D:\\dump.')
-	print('You can do this by clicking on My Computer while selecting a directory, double clicking on a hard drive, creating a directory named \'dump\', and selecting it.')
-	print('This will cause the least number of files to overflow.')
-print()
-input('Press Enter to continue and select a directory.')
-
 # --- SETTINGS ---
 
 parser = argparse.ArgumentParser(description='Download files from itslearning. Check the README for more information.')
@@ -113,6 +96,23 @@ output_text_extension = '.html'
 # The index is 1-indexed, and corresponds to the course index listed on the print messages in the console
 # when the dumping of a new course is started.
 skip_to_course_with_index = args.skip_to_course
+
+# --- INTRO ---
+
+print('----- It\'s Learning dump script -----')
+print('Created by: Bart van Blokland (bart.van.blokland@ntnu.no)')
+print()
+print('Greetings! This script will help you download your content off of It\'s Learning.')
+print('We\'ll start by selecting a directory where all the files are going to be saved.')
+if os.name == 'nt':
+	print()
+	print('NOTE: Since you\'re a Windows user, please keep in mind that file paths can only be 255 characters long. This is a Windows limitation I can\'t do anything about.')
+	print('This script has a fallback option for files which can not be created due to this limitation by saving them to a single directory.')
+	print('For the best results, I recommend creating a folder in the root of your hard drive. For example; C:\\dump or D:\\dump.')
+	print('You can do this by clicking on My Computer while selecting a directory, double clicking on a hard drive, creating a directory named \'dump\', and selecting it.')
+	print('This will cause the least number of files to overflow.')
+print()
+input('Press Enter to continue and select a directory.')
 
 # Determines where the program dumps its output. 
 # Note that the tailing slash is mandatory. 

--- a/scrape.py
+++ b/scrape.py
@@ -41,6 +41,7 @@ from lxml.html import fromstring, tostring
 from lxml import etree
 
 # Python std lib imports
+import argparse
 import os.path
 import os
 import re
@@ -81,10 +82,19 @@ input('Press Enter to continue and select a directory.')
 
 # --- SETTINGS ---
 
+parser = argparse.ArgumentParser(description='Download files from itslearning. Check the README for more information.')
+
+parser.add_argument('--rate-limit-delay', '-R', dest='rate_limit', type=int, default=1,
+					help="Rate limits requests to It's Learning (seconds). Defaults to 1 second.")
+parser.add_argument('--skip-to-course', '-S', dest='skip_to_course', type=int, default=0,
+					help='Skip to a course with a specific index. Useful after a crash.')
+
+args = parser.parse_args()
+
 # I've sprinkled delays around the code to ensure the script isn't spamming requests at maximum rate.
 # Each time such a delay occurs, it waits for this many seconds.
 # Feel free to increase this if you plan to run this script overnight.
-rate_limiting_delay_seconds = 1
+rate_limiting_delay_seconds = args.rate_limit
 
 # Some bits and pieces of text may contain special characters. Since a number of these are used
 # in file paths and file names, they have to be filtered out. 
@@ -102,7 +112,7 @@ output_text_extension = '.html'
 # If this value is non-zero, also downloading of the messaging inbox will be skipped.
 # The index is 1-indexed, and corresponds to the course index listed on the print messages in the console
 # when the dumping of a new course is started.
-skip_to_course_with_index = 0
+skip_to_course_with_index = args.skip_to_course
 
 # Determines where the program dumps its output. 
 # Note that the tailing slash is mandatory. 


### PR DESCRIPTION
Makes it possible to configure the script using command line arguments, rather than editing the script manually.

```
$ python scrape.py --help
usage: scrape.py [-h] [--rate-limit-delay RATE_LIMIT] [--skip-to-course SKIP_TO_COURSE]

Download files from itslearning. Check the README for more information.

optional arguments:
  -h, --help            show this help message and exit
  --rate-limit-delay RATE_LIMIT, -R RATE_LIMIT
                        Rate limits requests to It's Learning (seconds).
                        Defaults to 1 second.
  --skip-to-course SKIP_TO_COURSE, -S SKIP_TO_COURSE
                        Skip to a course with a specific index. Useful after a
                        crash.
```

Example execution: `python scrape.py --rate-limit 10` will delay each request by 10 seconds.