### PR TITLE
Lazy import tkinter

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -56,10 +56,6 @@ from urllib.parse import urlparse
 # Requires Python 3.4
 from pathlib import Path
 
-# User interface goodies
-import tkinter
-from tkinter.filedialog import askdirectory
-
 # --- SETTINGS ---
 
 parser = argparse.ArgumentParser(description='Download files from itslearning. Check the README for more information.')
@@ -123,6 +119,17 @@ is_directory_empty = False
 while not is_directory_empty:
 	if output_folder_name is None:
 		input('Press Enter to continue and select a directory.')
+		# User interface goodies
+		try:
+			# A bit ugly, but libraries already imported won't be imported again, so actually, all is good.
+			import tkinter
+			from tkinter.filedialog import askdirectory
+		except ImportError as ie:
+			print('')
+			print('!!! Could not import tkinter.')
+			print("If you don't have tkinter installed, specify the output dir by using the output parameter '--output-dir'")
+			print('')
+			raise ie
 		tkinter.Tk().withdraw()
 		output_folder_name = askdirectory()
 	if output_folder_name == '':

--- a/scrape.py
+++ b/scrape.py
@@ -56,7 +56,9 @@ from urllib.parse import urlparse
 # Requires Python 3.4
 from pathlib import Path
 
-
+# User interface goodies
+import tkinter
+from tkinter.filedialog import askdirectory
 
 # --- SETTINGS ---
 
@@ -74,12 +76,6 @@ parser.add_argument('--output-text-extension', '-E', dest='output_extension', de
 					help='Specifies the extension given to produced plaintext files. Values ought to be either \'.html\' or \'.txt\'.')
 
 args = parser.parse_args()
-
-
-# Delayed loading of tkinter to avoid doing so when executing in a non-graphical environment, where an output dir is specified as a command line argument.
-if args.output_dir is None:
-	import tkinter
-	from tkinter.filedialog import askdirectory
 
 # I've sprinkled delays around the code to ensure the script isn't spamming requests at maximum rate.
 # Each time such a delay occurs, it waits for this many seconds.
@@ -123,27 +119,24 @@ print()
 # Determines where the program dumps its output. 
 # Note that the tailing slash is mandatory. 
 output_folder_name = args.output_dir
-
-# Only try to show a file selection dialog if no override has been selected.
-if args.output_dir is None:
-	is_directory_empty = False
-	while not is_directory_empty:
-		if output_folder_name is None:
-			input('Press Enter to continue and select a directory.')
-			tkinter.Tk().withdraw()
-			output_folder_name = askdirectory()
-		if output_folder_name == '':
-			print('Folder selection cancelled. Aborting.')
-			sys.exit(0)
-		output_folder_name = os.path.abspath(output_folder_name)
-		is_directory_empty = not os.listdir(output_folder_name)
-		if not is_directory_empty:
-			print()
-			print('The selected directory is not empty, which the script needs to work properly.')
-			print('Press enter to try again, and select a new one.')
-			print('You can always create a new directory and select it; that one will always be empty.')
-			print()
-			input('Press Enter to continue and try selecting a directory again.')
+is_directory_empty = False
+while not is_directory_empty:
+	if output_folder_name is None:
+		input('Press Enter to continue and select a directory.')
+		tkinter.Tk().withdraw()
+		output_folder_name = askdirectory()
+	if output_folder_name == '':
+		print('Folder selection cancelled. Aborting.')
+		sys.exit(0)
+	output_folder_name = os.path.abspath(output_folder_name)
+	is_directory_empty = not os.listdir(output_folder_name)
+	if not is_directory_empty:
+		print()
+		print('The selected directory is not empty, which the script needs to work properly.')
+		print('Press enter to try again, and select a new one.')
+		print('You can always create a new directory and select it; that one will always be empty.')
+		print()
+		input('Press Enter to continue and try selecting a directory again.')
 print('Selected output folder:', output_folder_name)
 
 # If a crash occurs, the script can skip all elements in folders up to the point where it left off. 


### PR DESCRIPTION
Resolves #4.

This reverts the changes from daeaea0 which bypasses the "empty dir check", and implements lazy importing of tkinter if needed. Tkinter is not needed if an output directory is specified.

If tkinter cannot be imported (e.g. due to missing/misconfigured tkinter installation) a tip is also shown so that the user can specify the output dir manually.